### PR TITLE
Update session validation and paths for like/dislike

### DIFF
--- a/src/constants/Paths.ts
+++ b/src/constants/Paths.ts
@@ -44,8 +44,8 @@ const Paths = {
 
       // Everyone
       Progress: '/progress',
-      Like: '/:roadmapId([0-9]+)/like',
-      Dislike: '/:roadmapId([0-9]+)/dislike',
+      Like: '/like',
+      Dislike: '/dislike',
     },
     Delete: '/:roadmapId([0-9]+)',
   },

--- a/src/routes/roadmapsRoutes/RoadmapsUpdate.ts
+++ b/src/routes/roadmapsRoutes/RoadmapsUpdate.ts
@@ -17,7 +17,7 @@ import {
 
 const RoadmapsUpdate = Router({ mergeParams: true });
 
-RoadmapsUpdate.post('*', validateSession);
+RoadmapsUpdate.all('*', validateSession);
 
 // ! Owner only
 RoadmapsUpdate.post(


### PR DESCRIPTION
Changes include switching to 'RoadmapsUpdate.all' in RoadmapsUpdate.ts to apply 'validateSession' for all types of HTTP requests. This change is deemed necessary for better session validation.

Also in Paths.ts, the Like and Dislike paths were streamlined from '/:roadmapId([0-9]+)/like' and '/:roadmapId([0-9]+)/dislike' to '/like' and '/dislike' respectively to simplify their structure. Please note that in this case, the roadmapId will have to be passed in the request body or as a query parameter.